### PR TITLE
Fix a mistake in README to do with Template Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Parameters:
 > Returns JSON information for the program requested
 
 Function:
-`pc_sponsorship($slug)`
+`pc_sponsorship($id)`
 
 Parameters:
 
-`$slug`: The sponsorship's slug
+`$id`: The sponsorship's ID


### PR DESCRIPTION
Hey, just a small mistake in the README that might be confusing for someone using the plugin. No biggie but I figured I would fix it real quick.

calling `pc_sponsorship($slug)` does not work with the sponsorships
slug, but calling pc_sponsorship($id) with the corresponding
sponsorships ID does work.
